### PR TITLE
swap all swappable scooters + bugs in tests

### DIFF
--- a/classes/State.py
+++ b/classes/State.py
@@ -80,6 +80,12 @@ class State:
             distance_matrix.append(neighbour_distance)
         return distance_matrix
 
+    def get_max_number_of_swaps(self, cluster: Cluster):
+        return min(
+            min(len(cluster.scooters), self.vehicle.battery_inventory),
+            cluster.ideal_state,
+        )
+
     def get_possible_actions(self, number_of_neighbours=None, divide=None):
         """
         Enumerate all possible actions from the current state
@@ -103,10 +109,7 @@ class State:
             self.vehicle.scooter_inventory_capacity
             - len(self.vehicle.scooter_inventory),
         )
-        swaps = min(
-            min(len(self.current_cluster.scooters), self.vehicle.battery_inventory),
-            self.current_cluster.ideal_state,
-        )
+        swaps = self.get_max_number_of_swaps(self.current_cluster)
         drop_offs = max(
             min(
                 self.current_cluster.ideal_state - len(self.current_cluster.scooters),
@@ -347,3 +350,10 @@ class State:
                 for scooter in cluster.scooters
                 if scooter.id in sampled_scooter_ids
             ]
+
+    def get_random_cluster(self, exclude=None):
+        return random.choice(
+            [cluster for cluster in self.clusters if cluster.id != exclude.id]
+            if exclude
+            else self.clusters
+        )

--- a/classes/tests/test_events.py
+++ b/classes/tests/test_events.py
@@ -46,10 +46,14 @@ class EventsTests(unittest.TestCase):
 
         scooter_battery = scooter.battery
 
-        arrival_cluster = random.choice(self.world.state.clusters)
+        arrival_cluster = self.world.state.get_random_cluster()
 
         arrival_event = ScooterArrival(
-            self.departure_time + self.travel_time, scooter, arrival_cluster.id, 0, 3
+            self.departure_time + self.travel_time,
+            scooter,
+            arrival_cluster.id,
+            self.world.state.get_random_cluster(exclude=arrival_cluster).id,
+            3,
         )
 
         arrival_event.perform(self.world)
@@ -64,12 +68,8 @@ class EventsTests(unittest.TestCase):
         self.assertLess(scooter.battery, scooter_battery)
 
     def test_vehicle_arrival(self):
-        random_cluster_in_state = random.choice(
-            [
-                cluster
-                for cluster in self.large_world.state.clusters
-                if cluster.id != self.large_world.state.current_cluster.id
-            ]
+        random_cluster_in_state = self.world.state.get_random_cluster(
+            exclude=self.world.state.current_cluster
         )
         # Create a vehicle arrival event with a arrival time of 20 arriving at a random cluster in the world state
         vehicle_arrival = VehicleArrival(20, random_cluster_in_state.id)

--- a/decision/policies.py
+++ b/decision/policies.py
@@ -1,6 +1,7 @@
 import copy
+import random
 
-from classes import World
+from classes import World, Cluster, Action
 
 from scenario_simulation.scripts import estimate_reward
 
@@ -36,3 +37,32 @@ class RandomRolloutPolicy(Policy):
                 best_action = action
 
         return best_action
+
+
+class SwapAllPolicy(Policy):
+    @staticmethod
+    def get_best_action(world: World):
+        # Choose a random cluster
+        next_cluster: Cluster = random.choice(
+            [
+                cluster
+                for cluster in world.state.clusters
+                if cluster.id != world.state.current_cluster.id
+            ]
+        )
+
+        # Find all scooters that can be swapped there
+        swappable_scooters_ids = [
+            scooter.id for scooter in next_cluster.get_swappable_scooters()
+        ]
+
+        # Calculate how many scooters that can be swapped
+        number_of_scooters_to_swap = world.state.get_max_number_of_swaps(next_cluster)
+
+        # Return an action with no re-balancing, only scooter swapping
+        return Action(
+            battery_swaps=swappable_scooters_ids[:number_of_scooters_to_swap],
+            pick_ups=[],
+            delivery_scooters=[],
+            next_cluster=next_cluster.id,
+        )

--- a/decision/test.py
+++ b/decision/test.py
@@ -2,7 +2,7 @@ import unittest
 
 from classes import World, Action
 from clustering.scripts import get_initial_state
-from decision.policies import RandomRolloutPolicy
+from decision.policies import RandomRolloutPolicy, SwapAllPolicy
 
 
 class BasicDecisionTests(unittest.TestCase):
@@ -179,6 +179,12 @@ class BasicDecisionTests(unittest.TestCase):
 
     def test_random_rollout_policy(self):
         self.assertIsInstance(RandomRolloutPolicy.get_best_action(World(40)), Action)
+
+    def test_swap_all_policy(self):
+        action = SwapAllPolicy.get_best_action(World(40))
+        self.assertIsInstance(action, Action)
+        self.assertEqual(len(action.pick_ups), 0)
+        self.assertEqual(len(action.delivery_scooters), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### What problem/feature does this pull request fix/add?
Now have a simple benchmark policy that picks up the maximum number of swappable scooters in every cluster it visits. 
#### (if not a new problem) How was this problem solved earlier?

#### How did I fix this problem?
Implemented swap all swappable scooters class
### Checklist
- [x] All tests have passed
- [x] I have created new tests for this feature (may not be applicable to all pull requests)
- [x] I am pleased with the readability of the code (if not, state where you need input)

